### PR TITLE
Use Blaze._getTemplate to allow resolving into Blaze Components

### DIFF
--- a/dynamic_template.js
+++ b/dynamic_template.js
@@ -151,12 +151,29 @@ DynamicTemplate.prototype.create = function (options) {
 
       // is it a template name like "MyTemplate"?
       if (typeof template === 'string') {
-        tmpl = Template[template];
+        if (Blaze._getTemplate) {
+          tmpl = Blaze._getTemplate(template, function () {
+            return Template.instance();
+          });
+        }
+        else {
+          // Backwards compatibility for Meteor < 1.2.
+          tmpl = Template[template];
+        }
 
-        if (!tmpl)
+        if (!tmpl) {
           // as a fallback double check the user didn't actually define
           // a camelCase version of the template.
-          tmpl = Template[camelCase(template)];
+          if (Blaze._getTemplate) {
+            tmpl = Blaze._getTemplate(camelCase(template), function () {
+              return Template.instance();
+            });
+          }
+          else {
+            // Backwards compatibility for Meteor < 1.2.
+            tmpl = Template[camelCase(template)];
+          }
+        }
 
         if (!tmpl) {
           tmpl = Blaze.With({


### PR DESCRIPTION
With https://github.com/meteor/meteor/commit/eff8016b5a7a981fc56beb531ece52de5b3d7101 there is now a `Blaze._getTemplate` function which is better to use than accessing `Template[...]` directly. The reason is that then packages like [Blaze Components](https://github.com/peerlibrary/meteor-blaze-components) can override `Blaze._getTemplate` to provide resolving into components instead of bare templates.

I am not 100% sure if:

```javascript
function () {
  return Template.instance();
}
```

is the best way to get current template instance, maybe it is available already somewhere in this code-path? But it should work this way as well. But I do not like access to global variables which `Template.instance` uses internally. So if you know of any better way to access current template instance at that code point, that would be great.