### PR TITLE
Use Blaze._getTemplate to allow resolving into Blaze Components

### DIFF
--- a/dynamic_template.js
+++ b/dynamic_template.js
@@ -121,7 +121,7 @@ DynamicTemplate.prototype.create = function (options) {
   this.isCreated = true;
   this.isDestroyed = false;
 
-  var templateVar = ReactiveVar(null);
+  var templateVar = ReactiveVar(null, function (a, b) {return a === b});
 
   var view = Blaze.View('DynamicTemplate', function () {
     var thisView = this;

--- a/dynamic_template.js
+++ b/dynamic_template.js
@@ -218,12 +218,29 @@ DynamicTemplate.prototype.renderView = function (template) {
 
   // is it a template name like "MyTemplate"?
   if (typeof template === 'string') {
-    tmpl = Template[template];
+    if (Blaze._getTemplate) {
+      tmpl = Blaze._getTemplate(template, function () {
+        return Template.instance();
+      });
+    }
+    else {
+      // Backwards compatibility for Meteor < 1.2.
+      tmpl = Template[template];
+    }
 
-    if (!tmpl)
+    if (!tmpl) {
       // as a fallback double check the user didn't actually define
       // a camelCase version of the template.
-      tmpl = Template[camelCase(template)];
+      if (Blaze._getTemplate) {
+        tmpl = Blaze._getTemplate(camelCase(template), function () {
+          return Template.instance();
+        });
+      }
+      else {
+        // Backwards compatibility for Meteor < 1.2.
+        tmpl = Template[camelCase(template)];
+      }
+    }
 
     if (!tmpl) {
       tmpl = Blaze.With({


### PR DESCRIPTION
Same as #10, just against `master` which seems to be the branch all development is really happening?

With https://github.com/meteor/meteor/commit/eff8016b5a7a981fc56beb531ece52de5b3d7101 there is now a `Blaze._getTemplate` function which is better to use than accessing `Template[...]` directly. The reason is that then packages like [Blaze Components](https://github.com/peerlibrary/meteor-blaze-components) can override `Blaze._getTemplate` to provide resolving into components instead of bare templates.